### PR TITLE
CHECK-364 - Remove Terraform as deployment mechanism

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,15 @@ runs:
       env:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
       shell: bash
-      run: ./deploy.sh ${{ inputs.app-name }} ${{ inputs.git-sha || env.GIT_SHA }} ${{ inputs.deploy-environment }}
+# ./deploy.sh ${{ inputs.app-name }} ${{ inputs.git-sha || env.GIT_SHA }} ${{ inputs.deploy-environment }}
+      run: |
+        GIT_SHA="${{ inputs.git-sha || env.GIT_SHA }}"
+        echo "Preparing to deploy ${{ inputs.app-name }} version $GIT_HASH to ${{ inputs.deploy-environment }}"
+
+        TASK_DEFINITION_ARN=(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq '.taskDefinitionArns[0]')
+        aws ecs describe-task-definition --task-definition "arn:aws:ecs:eu-west-2:072814172821:task-definition/dev-checkout-mfe:1" > task-definition.json
+
+        #cat task-definition.json | jq '.taskDefinition.containerDefinitions[0].image' | sed 's/ecr\.[\w\d-]+\.amazonaws\.com\/[\w\d-]*:([\w\d]+)/
       
     - name: Create New Relic deployment marker
       uses: newrelic/deployment-marker-action@v1

--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,7 @@ runs:
     - name: Fetch Task Definition
       shell: bash
       run: |
-        TASK_DEFINITION_ARN=(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq '.taskDefinitionArns[0]')
+        TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq '.taskDefinitionArns[0]')
         aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" > task-definition.json
       
     - name: Update Task Definition

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,8 @@
 name: "Deploy MFE"
 description: "Deploy MFE to specified environment."
 inputs:
-  aws-access-key-id:
-    description: 'AWS Access Key Id'
-    required: true
-
-  aws-secret-access-key:
-    description: 'AWS Secret Access Key'
+  aws-role-to-assume:
+    description: 'ARN of the AWS IAM role to assume'
     required: true
 
   aws-region:
@@ -72,9 +68,11 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+
+    - run: aws sts get-caller-identity
+      shell: bash
         
     - name: Pull and tag image from previous environment
       if: inputs.is-initial-environment != 'true'

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,6 @@ runs:
       if: inputs.is-initial-environment != 'true'
       env:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
-      working-directory: ./mfe-infrastructure/ci
       shell: bash
       run: |
         aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin "${{ inputs.source-ecr }}"
@@ -93,7 +92,6 @@ runs:
       if: inputs.is-initial-environment != 'true'
       env:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
-      working-directory: ./mfe-infrastructure/ci
       shell: bash
       run: |
         docker image tag "${{ inputs.source-ecr }}:${{ env.GIT_SHA }}" "${{ inputs.destination-ecr }}:${{ env.GIT_SHA }}"
@@ -108,7 +106,6 @@ runs:
     - name: Deploy MFE
       env:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
-      working-directory: ./mfe-infrastructure/ci
       shell: bash
       run: ./deploy.sh ${{ inputs.app-name }} ${{ inputs.git-sha || env.GIT_SHA }} ${{ inputs.deploy-environment }}
       

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
 
   destination-ecr:
     description: 'If promoting from a previous environment, the ECR repository to promote to'
-    required: false
+    required: true
     
   git-sha:
     description: 'To deploy a specific git sha (e.g. for rollback), specify the short (7 char) git sha. The image must still be available in the relevant environment ECR.'
@@ -103,20 +103,29 @@ runs:
       with:
         terraform_version: 0.14.7
         
-    - name: Deploy MFE
-      env:
-        GIT_SHA: ${{ steps.short-sha.outputs.sha }}
+    - name: Fetch Task Definition
       shell: bash
-# ./deploy.sh ${{ inputs.app-name }} ${{ inputs.git-sha || env.GIT_SHA }} ${{ inputs.deploy-environment }}
       run: |
-        GIT_SHA="${{ inputs.git-sha || env.GIT_SHA }}"
-        echo "Preparing to deploy ${{ inputs.app-name }} version $GIT_HASH to ${{ inputs.deploy-environment }}"
-
         TASK_DEFINITION_ARN=(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq '.taskDefinitionArns[0]')
-        aws ecs describe-task-definition --task-definition "arn:aws:ecs:eu-west-2:072814172821:task-definition/dev-checkout-mfe:1" > task-definition.json
-
-        #cat task-definition.json | jq '.taskDefinition.containerDefinitions[0].image' | sed 's/ecr\.[\w\d-]+\.amazonaws\.com\/[\w\d-]*:([\w\d]+)/
+        aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" > task-definition.json
       
+    - name: Update Task Definition
+      id: update-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition
+      with:
+        task-definition: task-definition.json
+        container-name: dev-checkout-mfe
+        image: "${{ inputs.destination-ecr}}:${{ steps.short-sha.outputs.sha }}"
+        #environment-variables
+
+    - name: Deploy to Amazon ECS service
+      users: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.update-task-definition.outputs.task-definition }}
+        service: dev-checkout-mfe
+        cluster: dev-ecs-fargate
+        wait-for-service-stability: ${{ inputs.deploy-environment != 'dev' }}
+    
     - name: Create New Relic deployment marker
       uses: newrelic/deployment-marker-action@v1
       env:

--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
         task-definition: ${{ steps.update-task-definition.outputs.task-definition }}
         service: "${{ inputs.deploy-environment }}-${{ inputs.app-name }}"
         cluster: "${{ inputs.deploy-environment }}-ecs-fargate"
-        wait-for-service-stability: ${{ inputs.deploy-environment != "dev" }}
+        wait-for-service-stability: ${{ inputs.deploy-environment != 'dev' }}
     
     # - name: Create New Relic deployment marker
     #   uses: newrelic/deployment-marker-action@v1

--- a/action.yml
+++ b/action.yml
@@ -107,6 +107,8 @@ runs:
       shell: bash
       run: |
         TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq '.taskDefinitionArns[0]')
+        echo "$TASK_DEFINITION_ARN"
+        echo $TASK_DEFINITION_ARN
         aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" > task-definition.json
       
     - name: Update Task Definition

--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
         wait-for-service-stability: ${{ inputs.deploy-environment != 'dev' }}
 
     - name: Create New Relic deployment marker
-      if: ${{ inputs.inform-new-relic }}
+      if: ${{ inputs.inform-new-relic == 'true'}}
       uses: newrelic/deployment-marker-action@v1
       env:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}

--- a/action.yml
+++ b/action.yml
@@ -2,56 +2,61 @@ name: "Deploy MFE"
 description: "Deploy MFE to specified environment."
 inputs:
   aws-role-to-assume:
-    description: 'ARN of the AWS IAM role to assume'
+    description: "ARN of the AWS IAM role to assume"
     required: true
 
   aws-region:
-    description: 'AWS Resource Region'
+    description: "AWS Resource Region"
     required: true
 
   submodules-pat:
-    description: 'Submodule personal access token'
+    description: "Submodule personal access token"
     required: true
 
   new-relic-api-key:
-    description: 'New Relic API Key'
+    description: "New Relic API Key"
     required: true
 
   new-relic-account-id:
-    description: 'New Relic Account Id'
+    description: "New Relic Account Id"
     required: true
 
   new-relic-application-id:
-    description: 'New Relic Application Id'
+    description: "New Relic Application Id"
     required: true
 
   new-relic-region:
-    description: 'New Relic Region'
+    description: "New Relic Region"
     required: true
 
   deploy-environment:
-    description: 'The AWS deployment environment account '
+    description: "The AWS deployment environment account "
     required: true
-  
+
   app-name:
-    description: 'MFE app name (e.g. search-mfe, property-details-mfe)'
+    description: "MFE app name (e.g. search-mfe, property-details-mfe)"
     required: true
-    
+
   is-initial-environment:
-    description: 'Is a deployment to the initial environment (true/false)'
+    description: "Is a deployment to the initial environment (true/false)"
     required: false
-    
+
   source-ecr:
-    description: 'If promoting from a previous environment, the ECR repository to promote from'
+    description: "If promoting from a previous environment, the ECR repository to promote from"
     required: false
 
   ecr-url:
-    description: 'URL of the MFE application ECR repository to in the account to deploy to'
+    description: "URL of the MFE application ECR repository to in the account to deploy to"
     required: true
-    
+
   git-sha:
-    description: 'To deploy a specific git sha (e.g. for rollback), specify the short (7 char) git sha. The image must still be available in the relevant environment ECR.'
+    description: "To deploy a specific git sha (e.g. for rollback), specify the short (7 char) git sha. The image must still be available in the relevant environment ECR."
     required: false
+
+  inform-new-relic:
+    description: "Whether to inform new relic that the deployment has taken place"
+    required: false
+    default: true
 
 runs:
   using: "composite"
@@ -59,12 +64,12 @@ runs:
     - uses: actions/checkout@v2
       with:
         token: ${{ inputs.submodules-pat }}
-        submodules: 'true'
+        submodules: "true"
     - uses: benjlevesque/short-sha@v1.2
       id: short-sha
       with:
         length: 7
-     
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -73,7 +78,7 @@ runs:
 
     - run: aws sts get-caller-identity
       shell: bash
-        
+
     - name: Pull and tag image from previous environment
       if: inputs.is-initial-environment != 'true'
       env:
@@ -82,12 +87,12 @@ runs:
       run: |
         aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin "${{ inputs.source-ecr }}"
         docker pull ${{ inputs.source-ecr }}:${{ env.GIT_SHA }}
-        
+
     - name: Login to Amazon ECR
       if: inputs.is-initial-environment != 'true'
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
-      
+
     - name: Promote image from previous environment
       if: inputs.is-initial-environment != 'true'
       env:
@@ -98,17 +103,17 @@ runs:
         docker image tag "${{ inputs.source-ecr }}:${{ env.GIT_SHA }}" "${{ inputs.ecr-url }}:latest"
         docker image push "${{ inputs.ecr-url }}:${{ env.GIT_SHA }}"
         docker image push "${{ inputs.ecr-url }}:latest"
-        
+
     - uses: hashicorp/setup-terraform@v1
       with:
         terraform_version: 0.14.7
-        
+
     - name: Fetch Task Definition
       shell: bash
       run: |
         TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix "${{ inputs.deploy-environment }}-${{ inputs.app-name }}" --sort DESC | jq -r '.taskDefinitionArns[0]')
         aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" | jq '.taskDefinition' > task-definition.json
-      
+
     - name: Update Task Definition
       id: update-task-definition
       uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -125,17 +130,18 @@ runs:
         service: "${{ inputs.deploy-environment }}-${{ inputs.app-name }}"
         cluster: "${{ inputs.deploy-environment }}-ecs-fargate"
         wait-for-service-stability: ${{ inputs.deploy-environment != 'dev' }}
-    
-    # - name: Create New Relic deployment marker
-    #   uses: newrelic/deployment-marker-action@v1
-    #   env:
-    #     GIT_SHA: ${{ steps.short-sha.outputs.sha }}
-    #   with:
-    #     apiKey: ${{ inputs.new-relic-api-key }}
-    #     accountId: ${{ inputs.new-relic-account-id }}
-    #     applicationId: ${{ inputs.new-relic-application-id }}
-    #     revision: '${{ env.GIT_SHA }}'
-    #     changelog: 'See https://github.com/${{ github.repository }}/commit/${{ env.GIT_SHA }} for changes.'
-    #     description: ${{ github.event.head_commit.message }}
-    #     region: ${{ inputs.new-relic-region}}
-    #     user: '${{ github.actor }}'
+
+    - name: Create New Relic deployment marker
+      if: ${{ inputs.inform-new-relic }}
+      uses: newrelic/deployment-marker-action@v1
+      env:
+        GIT_SHA: ${{ steps.short-sha.outputs.sha }}
+      with:
+        apiKey: ${{ inputs.new-relic-api-key }}
+        accountId: ${{ inputs.new-relic-account-id }}
+        applicationId: ${{ inputs.new-relic-application-id }}
+        revision: "${{ env.GIT_SHA }}"
+        changelog: "See https://github.com/${{ github.repository }}/commit/${{ env.GIT_SHA }} for changes."
+        description: ${{ github.event.head_commit.message }}
+        region: ${{ inputs.new-relic-region}}
+        user: "${{ github.actor }}"

--- a/action.yml
+++ b/action.yml
@@ -127,16 +127,16 @@ runs:
         cluster: dev-ecs-fargate
         wait-for-service-stability: false
     
-    - name: Create New Relic deployment marker
-      uses: newrelic/deployment-marker-action@v1
-      env:
-        GIT_SHA: ${{ steps.short-sha.outputs.sha }}
-      with:
-        apiKey: ${{ inputs.new-relic-api-key }}
-        accountId: ${{ inputs.new-relic-account-id }}
-        applicationId: ${{ inputs.new-relic-application-id }}
-        revision: '${{ env.GIT_SHA }}'
-        changelog: 'See https://github.com/${{ github.repository }}/commit/${{ env.GIT_SHA }} for changes.'
-        description: ${{ github.event.head_commit.message }}
-        region: ${{ inputs.new-relic-region}}
-        user: '${{ github.actor }}'
+    # - name: Create New Relic deployment marker
+    #   uses: newrelic/deployment-marker-action@v1
+    #   env:
+    #     GIT_SHA: ${{ steps.short-sha.outputs.sha }}
+    #   with:
+    #     apiKey: ${{ inputs.new-relic-api-key }}
+    #     accountId: ${{ inputs.new-relic-account-id }}
+    #     applicationId: ${{ inputs.new-relic-application-id }}
+    #     revision: '${{ env.GIT_SHA }}'
+    #     changelog: 'See https://github.com/${{ github.repository }}/commit/${{ env.GIT_SHA }} for changes.'
+    #     description: ${{ github.event.head_commit.message }}
+    #     region: ${{ inputs.new-relic-region}}
+    #     user: '${{ github.actor }}'

--- a/action.yml
+++ b/action.yml
@@ -111,7 +111,7 @@ runs:
       
     - name: Update Task Definition
       id: update-task-definition
-      uses: aws-actions/amazon-ecs-render-task-definition
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: task-definition.json
         container-name: dev-checkout-mfe

--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,8 @@ inputs:
     description: 'If promoting from a previous environment, the ECR repository to promote from'
     required: false
 
-  destination-ecr:
-    description: 'If promoting from a previous environment, the ECR repository to promote to'
+  ecr-url:
+    description: 'URL of the MFE application ECR repository to in the account to deploy to'
     required: true
     
   git-sha:
@@ -106,16 +106,15 @@ runs:
     - name: Fetch Task Definition
       shell: bash
       run: |
-        TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq -r '.taskDefinitionArns[0]')
+        TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix "${{ inputs.deploy-environment }}-${{ inputs.app-name }}" --sort DESC | jq -r '.taskDefinitionArns[0]')
         aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" | jq '.taskDefinition' > task-definition.json
-        cat task-definition.json
       
     - name: Update Task Definition
       id: update-task-definition
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: task-definition.json
-        container-name: dev-checkout-mfe
+        container-name: "${{ inputs.deploy-environment }}-${{ inputs.app-name }}"
         image: "${{ inputs.destination-ecr}}:${{ steps.short-sha.outputs.sha }}"
         #environment-variables
 
@@ -123,9 +122,9 @@ runs:
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1
       with:
         task-definition: ${{ steps.update-task-definition.outputs.task-definition }}
-        service: dev-checkout-mfe
-        cluster: dev-ecs-fargate
-        wait-for-service-stability: false
+        service: "${{ inputs.deploy-environment }}-${{ inputs.app-name }}"
+        cluster: "${{ inputs.deploy-environment }}-ecs-fargate"
+        wait-for-service-stability: ${{ inputs.deploy-environment != "dev" }}
     
     # - name: Create New Relic deployment marker
     #   uses: newrelic/deployment-marker-action@v1

--- a/action.yml
+++ b/action.yml
@@ -94,10 +94,10 @@ runs:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
       shell: bash
       run: |
-        docker image tag "${{ inputs.source-ecr }}:${{ env.GIT_SHA }}" "${{ inputs.destination-ecr }}:${{ env.GIT_SHA }}"
-        docker image tag "${{ inputs.source-ecr }}:${{ env.GIT_SHA }}" "${{ inputs.destination-ecr }}:latest"
-        docker image push "${{ inputs.destination-ecr }}:${{ env.GIT_SHA }}"
-        docker image push "${{ inputs.destination-ecr }}:latest"
+        docker image tag "${{ inputs.source-ecr }}:${{ env.GIT_SHA }}" "${{ inputs.ecr-url }}:${{ env.GIT_SHA }}"
+        docker image tag "${{ inputs.source-ecr }}:${{ env.GIT_SHA }}" "${{ inputs.ecr-url }}:latest"
+        docker image push "${{ inputs.ecr-url }}:${{ env.GIT_SHA }}"
+        docker image push "${{ inputs.ecr-url }}:latest"
         
     - uses: hashicorp/setup-terraform@v1
       with:
@@ -115,7 +115,7 @@ runs:
       with:
         task-definition: task-definition.json
         container-name: "${{ inputs.deploy-environment }}-${{ inputs.app-name }}"
-        image: "${{ inputs.destination-ecr}}:${{ steps.short-sha.outputs.sha }}"
+        image: "${{ inputs.ecr-url}}:${{ steps.short-sha.outputs.sha }}"
         #environment-variables
 
     - name: Deploy to Amazon ECS service

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ runs:
         task-definition: ${{ steps.update-task-definition.outputs.task-definition }}
         service: dev-checkout-mfe
         cluster: dev-ecs-fargate
-        wait-for-service-stability: true
+        wait-for-service-stability: false
     
     - name: Create New Relic deployment marker
       uses: newrelic/deployment-marker-action@v1

--- a/action.yml
+++ b/action.yml
@@ -106,9 +106,7 @@ runs:
     - name: Fetch Task Definition
       shell: bash
       run: |
-        TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq '.taskDefinitionArns[0]')
-        echo "$TASK_DEFINITION_ARN"
-        echo $TASK_DEFINITION_ARN
+        TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq -r '.taskDefinitionArns[0]')
         aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" > task-definition.json
       
     - name: Update Task Definition

--- a/action.yml
+++ b/action.yml
@@ -108,6 +108,7 @@ runs:
       run: |
         TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq -r '.taskDefinitionArns[0]')
         aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" > task-definition.json
+        cat task-definition.json
       
     - name: Update Task Definition
       id: update-task-definition

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ runs:
         task-definition: ${{ steps.update-task-definition.outputs.task-definition }}
         service: dev-checkout-mfe
         cluster: dev-ecs-fargate
-        wait-for-service-stability: ${{ inputs.deploy-environment != 'dev' }}
+        wait-for-service-stability: true
     
     - name: Create New Relic deployment marker
       uses: newrelic/deployment-marker-action@v1

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
         #environment-variables
 
     - name: Deploy to Amazon ECS service
-      users: aws-actions/amazon-ecs-deploy-task-definition@v1
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
       with:
         task-definition: ${{ steps.update-task-definition.outputs.task-definition }}
         service: dev-checkout-mfe

--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
       shell: bash
       run: |
         TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix dev-checkout-mfe --sort DESC | jq -r '.taskDefinitionArns[0]')
-        aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" > task-definition.json
+        aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" | jq '.taskDefinition' > task-definition.json
         cat task-definition.json
       
     - name: Update Task Definition

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,23 @@ runs:
     - name: Fetch Task Definition
       shell: bash
       run: |
-        TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix "${{ inputs.deploy-environment }}-${{ inputs.app-name }}" --sort DESC | jq -r '.taskDefinitionArns[0]')
-        aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" | jq '.taskDefinition' > task-definition.json
+        echo 'Fetching latest task definition arn'
+        TASK_DEFINITION_ARN=$(aws ecs list-task-definitions --family-prefix "${{ inputs.deploy-environment }}-${{ inputs.app-name }}" --sort DESC |\
+          jq -r '.taskDefinitionArns[0]')
+        
+        echo 'Fetching task definition'
+        aws ecs describe-task-definition --task-definition "$TASK_DEFINITION_ARN" >  task-definition-intitial.json
+
+        echo 'Cutting task definition down to what the input version should look like'
+        cat task-definition-intitial.json |\
+          jq '.taskDefinition' |\
+          jq 'del(.compatibilities)' |\
+          jq 'del(.taskDefinitionArn)' |\
+          jq 'del(.requiresAttributes)' |\
+          jq 'del(.revision)' |\
+          jq 'del(.status)' |\
+          jq 'del(.registeredAt)' |\
+          jq 'del(.registeredBy)' > task-definition.json
 
     - name: Update Task Definition
       id: update-task-definition


### PR DESCRIPTION
Move away from the mfe-infrastructure submodule and inline the deployment into the action. The major change to this action is to stop using terraform to deploy application updates to the MFE. Instead, we use aws CLI commands to update and deploy the ECS service for our MFEs. 

The deploy step has become the following:
1. Pull down the latest task definition
2. Replace the image tag for the mfe application container in the task definition
3. Deploy the new task definition to the ECS service

Also:
- Switch the action to using AWS IAM role rather than user credentials
- Rename the "destination-ecr" parameter to "ecr-url" and make it always required.


## For Discussion
- How often do the task definitions change?
  - This mechanism doesn't support changing anything but the image at the moment, do we want to add support for changing the task definition whole sale into this at a later time?